### PR TITLE
Switch to ipaddr instead of ipaddress

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,6 @@ requires = python >= 2.6
            PyYAML >= 3.10
            libyaml-devel >= 0.1.3
            python-geoip2 >= 2.1.0
-           python-ipaddress >= 1.0.19
+           python-ipaddr >= 2.1.0
            python-maxminddb >= 1.2.0
            libmaxminddb-devel >= 1.0.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pgwrr',
       install_requires=[
           'PyYAML >= 3.10',
           'geoip2 >= 2.1.0',
-          'ipaddress >= 1.0.19',
+          'ipaddr >= 2.1.0',
           'maxminddb >= 1.2.0',
       ],
       zip_safe=False)


### PR DESCRIPTION
- Backwards compatibility with CentOS 6
- Ports private network list from ipaddress